### PR TITLE
Fixing the faulty QuillEditorComponent#setHtmlContent JS call + other fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,8 +90,7 @@
     <dependencies>
         <dependency>
             <groupId>com.vaadin</groupId>
-            <!-- Replace artifactId with vaadin-core to use only free components -->
-            <artifactId>vaadin</artifactId>
+            <artifactId>vaadin-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -127,7 +126,7 @@
                 <version>9.4.31.v20200723</version>
                 <configuration>
                     <scanIntervalSeconds>-1</scanIntervalSeconds>
-                    <!-- Use test scope because the UI/test classes are in 
+                    <!-- Use test scope because the UI/test classes are in
                         the test package. -->
                     <useTestScope>true</useTestScope>
                     <supportedPackagings>
@@ -210,5 +209,3 @@
         </profile>
     </profiles>
 </project>
-
-

--- a/src/main/java/org/vaadin/klaudeta/quill/QuillEditorComponent.java
+++ b/src/main/java/org/vaadin/klaudeta/quill/QuillEditorComponent.java
@@ -1,5 +1,7 @@
 package org.vaadin.klaudeta.quill;
 
+import java.util.Objects;
+
 import com.vaadin.flow.component.ClientCallable;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasComponents;
@@ -13,12 +15,10 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.dom.DisabledUpdateMode;
 import com.vaadin.flow.function.SerializableConsumer;
-import java.util.Objects;
 
 /**
  * A custom RichText editor component for Flow using Quill library.
  */
-
 @Tag("quill-editor")
 @NpmPackage(value = "lit-element", version = "^2.2.1")
 @NpmPackage(value = "lit-html", version = "^1.1.2")
@@ -49,9 +49,7 @@ public class QuillEditorComponent extends Component implements HasComponents, Qu
         editor.setId("editor-quill");
         add(editor);
         this.getElement().executeJs("$0.initEditor($1)",this, editor.getElement());
-
     }
-
 
     @ClientCallable(DisabledUpdateMode.ALWAYS)
     private void setHtml(String htmlContent) {
@@ -85,14 +83,14 @@ public class QuillEditorComponent extends Component implements HasComponents, Qu
         if(!Objects.equals(oldContent, htmlContent)){
             this.htmlContent = htmlContent;
             runBeforeClientResponse(ui -> {
-                editor.getElement().callJsFunction("$0.setHtml($1)", this,  htmlContent);
+                editor.getElement().executeJs("$0.setHtml($1)", this,  htmlContent);
             });
         }
-
     }
 
     private void runBeforeClientResponse(SerializableConsumer<UI> command) {
         getElement().getNode().runWhenAttached(ui -> ui
                 .beforeClientResponse(this, context -> command.accept(ui)));
     }
+
 }

--- a/src/main/java/org/vaadin/klaudeta/quill/QuillEditorComponent.java
+++ b/src/main/java/org/vaadin/klaudeta/quill/QuillEditorComponent.java
@@ -24,8 +24,8 @@ import com.vaadin.flow.function.SerializableConsumer;
 @NpmPackage(value = "lit-html", version = "^1.1.2")
 @NpmPackage(value = "quill", version = "^1.3.6")
 @JsModule("./quilleditor.js")
-@CssImport("quill.snow.css")
-@CssImport(value = "./custom-quillEditor.css")
+@CssImport("./quill.snow.css")
+@CssImport("./custom-quillEditor.css")
 public class QuillEditorComponent extends Component implements HasComponents, QuillToolbarConfigurator, HasSize, QuillValueChangeNotifier, HasStyle {
 
     public static final String EMPTY_VALUE = "<p><br></p>";

--- a/src/main/java/org/vaadin/klaudeta/quill/QuillToolbarConfigurator.java
+++ b/src/main/java/org/vaadin/klaudeta/quill/QuillToolbarConfigurator.java
@@ -53,7 +53,7 @@ public interface QuillToolbarConfigurator extends HasElement {
     }
 
     /**
-     * Configuring the editor to not include the ordered & bullet lists commands:
+     * Configuring the editor to not include the ordered &amp; bullet lists commands:
      *
      * @return this instance of the {@link QuillEditorComponent} as a QuillToolbarConfiguration
      */
@@ -113,7 +113,7 @@ public interface QuillToolbarConfigurator extends HasElement {
     }
 
     /**
-     * Configuring the editor to not include the font & background color options:
+     * Configuring the editor to not include the font &amp; background color options:
      *
      * @return this instance of the {@link QuillEditorComponent} as a QuillToolbarConfiguration
      */

--- a/src/main/resources/META-INF/frontend/custom-quillEditor.css
+++ b/src/main/resources/META-INF/frontend/custom-quillEditor.css
@@ -1,4 +1,4 @@
-.ql-snow .ql-picker.ql-size .ql-picker-label[data-value="32px"]::before{
+.ql-snow .ql-picker.ql-size .ql-picker-label[data-value="32px"]::before {
     content: 'Huge';
 }
 .ql-snow .ql-picker.ql-size .ql-picker-item[data-value="32px"]::before {
@@ -6,7 +6,7 @@
     font-size: 32px;
 }
 
-.ql-snow .ql-picker.ql-size .ql-picker-label[data-value="18px"]::before{
+.ql-snow .ql-picker.ql-size .ql-picker-label[data-value="18px"]::before {
     content: 'Large';
 }
 .ql-snow .ql-picker.ql-size .ql-picker-item[data-value="18px"]::before {
@@ -14,7 +14,7 @@
     font-size: 18px;
 }
 
-.ql-snow .ql-picker.ql-size .ql-picker-label[data-value="10px"]::before{
+.ql-snow .ql-picker.ql-size .ql-picker-label[data-value="10px"]::before {
     content: 'Small';
 }
 .ql-snow .ql-picker.ql-size .ql-picker-item[data-value="10px"]::before {
@@ -22,7 +22,7 @@
     font-size: 10px;
 }
 
-.ql-snow .ql-editor{
+.ql-snow .ql-editor {
     /*min-height: 200px;*/
     height: 100%;
 }
@@ -35,7 +35,8 @@
     height: 100%;
 }
 
-.ql-container.ql-snow.ql-readonly{
+.ql-container.ql-snow.ql-readonly {
+    overflow: auto;
     padding:10px;
 }
 
@@ -43,7 +44,7 @@
     display: block;
 }
 
-.quill-editor .error-message{
+.quill-editor .error-message {
     margin-left: calc(var(--lumo-border-radius-m) / 4);
     font-size: var(--lumo-font-size-xs);
     line-height: var(--lumo-line-height-xs);
@@ -52,14 +53,10 @@
     transition: 0.4s max-height;
     max-height: 5em;
 }
-.quill-editor .editor{
+.quill-editor .editor {
     height: 90%;
 }
 
-.quill-editor .invalid{
+.quill-editor .invalid {
     background-color: var(--lumo-error-color-10pct);
 }
-
-
-
-

--- a/src/main/resources/META-INF/frontend/quilleditor.js
+++ b/src/main/resources/META-INF/frontend/quilleditor.js
@@ -185,11 +185,11 @@ class QuillEditor extends LitElement{
     }
 
     getHtml() {
-        return quill.root.innerHTML;
+        return this.quillEditor.root.innerHTML;
     }
 
     setHtml(htmlContent) {
-        quill.root.innerHTML = htmlContent;
+        this.quillEditor.root.innerHTML = htmlContent;
     }
 }
 

--- a/src/test/java/org/vaadin/klaudeta/quill/QuillEditorBindingTestView.java
+++ b/src/test/java/org/vaadin/klaudeta/quill/QuillEditorBindingTestView.java
@@ -2,6 +2,7 @@ package org.vaadin.klaudeta.quill;
 
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.data.binder.Binder;
@@ -15,43 +16,48 @@ import com.vaadin.flow.router.Route;
 public class QuillEditorBindingTestView extends VerticalLayout {
 
     public QuillEditorBindingTestView() {
-        Div readOnlyContent = new Div();
-        Binder<Bean> beanBinder = new Binder<>();
+        TextField title = new TextField("Title");
+        title.setWidth("20em");
 
-        TextField title = new TextField();
         QuillEditor quillEditor = new QuillEditor();
-        quillEditor.setHeight("300px");
-
+        quillEditor.setHeight("20em");
         add(title, quillEditor);
 
-        beanBinder.forField(title).asRequired("Title is mandatory!")
-        .bind(Bean::getTitle, Bean::setContent);
+        Binder<Bean> beanBinder = new Binder<>();
+        beanBinder.forField(title)
+                //.asRequired("Title is mandatory!")
+                .bind(Bean::getTitle, Bean::setTitle);
 
-        beanBinder
-                .forField(quillEditor)
-                .asRequired("Content is mandatory")
+        beanBinder.forField(quillEditor)
+                .asRequired("Content is mandatory!")
                 .bind(Bean::getContent, Bean::setContent);
 
-
         beanBinder.setBean(new Bean());
+
+        Div readOnlyContent = new Div();
+        readOnlyContent.getStyle().set("overflow", "auto");
+        readOnlyContent.setHeight("20em");
+        readOnlyContent.setWidth("20em");
+
         Button save = new Button("Save");
         save.addClickListener(event -> {
-            beanBinder.validate();
-           if(beanBinder.isValid()){
+           if (beanBinder.validate().isOk()) {
                readOnlyContent.getElement().setProperty("innerHTML", quillEditor.getValue());
-           }else {
+           } else {
                readOnlyContent.getElement().setProperty("innerHTML", quillEditor.getErrorMessage());
            }
-
         });
 
-        add(save, readOnlyContent);
+        add(new HorizontalLayout(
+                new Button("Clear Editor", event -> quillEditor.clear()),
+                new Button("Toggle ReadOnly", event -> quillEditor.setReadOnly(!quillEditor.isReadOnly())),
+                save
+        ), readOnlyContent);
 
         this.setSizeFull();
     }
 
     static class Bean{
-
         String title;
         String content;
 
@@ -71,4 +77,5 @@ public class QuillEditorBindingTestView extends VerticalLayout {
             this.content = content;
         }
     }
+
 }

--- a/src/test/java/org/vaadin/klaudeta/quill/TestView.java
+++ b/src/test/java/org/vaadin/klaudeta/quill/TestView.java
@@ -1,6 +1,8 @@
 package org.vaadin.klaudeta.quill;
 
+import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.router.Route;
 
@@ -13,14 +15,19 @@ public class TestView extends VerticalLayout {
 
     public TestView() {
         QuillEditor quillEditor = new QuillEditor();
-
-        quillEditor.getToolbarConfigurator().noFontDecorators()
-                .noColors().initEditor();
-
+        quillEditor.getToolbarConfigurator().noFontDecorators().noColors().initEditor();
+        quillEditor.setHeight("20em");
         add(quillEditor);
 
-        quillEditor.setHeight("60%");
+        add(new HorizontalLayout(
+                new Button("Clear Editor", event -> quillEditor.clear()),
+                new Button("Toggle ReadOnly", event -> quillEditor.setReadOnly(!quillEditor.isReadOnly()))
+        ));
+
         Div div = new Div();
+        div.getStyle().set("overflow", "auto");
+        div.setHeight("20em");
+        div.setWidth("20em");
         add(div);
 
         quillEditor.addValueChangeListener(event -> {
@@ -29,4 +36,5 @@ public class TestView extends VerticalLayout {
 
         this.setSizeFull();
     }
+
 }


### PR DESCRIPTION
Hi!

This is a really nice addon - kudos for the initial version! 

Unfortunately it has some flaws and I'd like to fix a couple with this PR.

1. Replaced the `callJsFunction` call in QuillEditorComponent.java which should be an `executeJs` one with the given JS code and parameters. The callJsFunction version called: `return $0.$0.setHtml($1)($1,$2)`. 😮 (spotted by @kalmancsaba thx!)

2. Fixed `quill` references to `this.quillEditor` in quilleditor.js to prevent JS errors.

3. Changed `vaadin` dependency to `vaadin-core` in pom.xml to exclude commercial Vaadin packages from the project.

4. Added "clear" and "readonly toggle" buttons to test views. Clear was definitely broken with the `callJsFunction` version. With the new buttons one can tests these features too.

5. Added `overflow: auto;` to the readonly editor (div) class to prevent text overflow in readonly editor mode.