### PR TITLE
Updated @NpmPackage versions to make them compatible with vaadin 23.

### DIFF
--- a/src/main/java/org/vaadin/klaudeta/quill/QuillEditorComponent.java
+++ b/src/main/java/org/vaadin/klaudeta/quill/QuillEditorComponent.java
@@ -20,8 +20,8 @@ import com.vaadin.flow.function.SerializableConsumer;
  * A custom RichText editor component for Flow using Quill library.
  */
 @Tag("quill-editor")
-@NpmPackage(value = "lit-element", version = "^2.2.1")
-@NpmPackage(value = "lit-html", version = "^1.1.2")
+@NpmPackage(value = "lit-element", version = "^3.0.0")
+@NpmPackage(value = "lit-html", version = "^2.4.0")
 @NpmPackage(value = "quill", version = "^1.3.6")
 @JsModule("./quilleditor.js")
 @CssImport("./quill.snow.css")


### PR DESCRIPTION
Vaadin 23 uses frontend/generated/lit-renderer.ts. This uses lit@2. 4. 1. 
 lit@2. 4. 1 uses the following export: lit-html/is-server.js
The file is-server.js got only introduced in lit-html@2.4.0
The @Npm import of lit-html@1.1.2 in QuillEditorComponent forced npm to load only lit-html@1.1.2
So lit-renderer.ts wouldn't work anymore.
Updating the versions fixes the issue.